### PR TITLE
Removed retired exam

### DIFF
--- a/src/content/docs/vouchers/aiskillsfest.mdx
+++ b/src/content/docs/vouchers/aiskillsfest.mdx
@@ -46,7 +46,6 @@ Eligible exams:
 - [SC-200: Security Operations Analyst Associate](https://learn.microsoft.com/en-us/certifications/security-operations-analyst/?WT.mc_id=studentamb_165290)
 - [AI-900: Azure AI Fundamentals](https://learn.microsoft.com/en-us/certifications/azure-ai-fundamentals/?WT.mc_id=studentamb_165290)
 - [DP-100: Designing and Implementing a Data Science Solution on Azure](https://learn.microsoft.com/en-us/certifications/azure-data-scientist/?WT.mc_id=studentamb_165290)
-- [DP-203 (retired): Azure Data Engineer Associate](https://learn.microsoft.com/en-us/certifications/azure-data-engineer/?WT.mc_id=studentamb_165290)
 - [DP-300: Azure Database Administrator Associate](https://learn.microsoft.com/en-us/certifications/azure-database-administrator-associate/?WT.mc_id=studentamb_165290)
 - [DP-420: Azure Cosmos DB Developer Specialty](https://learn.microsoft.com/en-us/certifications/azure-cosmos-db-developer-specialty/?WT.mc_id=studentamb_165290)
 - [DP-600: Implementing Analytics Solutions Using Microsoft Fabric](https://learn.microsoft.com/en-us/certifications/azure-data-engineer/?WT.mc_id=studentamb_165290)


### PR DESCRIPTION
It's also no longer mentioned on the Skills Fest site

https://learn.microsoft.com/en-gb/training/topics/event-challenges/ai-skills-fest-challenge-official-rules?WT.mc_id=studentamb_165290#:~:text=%245%2C000%2C000.-,Codes%20can%20be%20used%20for%20the%20following%20certification%20exams%3A,-DP%2D700