### PR TITLE
(fix) MS-102 study guide URL

### DIFF
--- a/src/content/docs/microsoft365/MS-102.mdx
+++ b/src/content/docs/microsoft365/MS-102.mdx
@@ -10,7 +10,7 @@ import { Aside } from '@astrojs/starlight/components';
 
   <LinkCard title="Exam MS-102: Microsoft 365 Administrator" href="https://learn.microsoft.com/credentials/certifications/m365-administrator-expert/?WT.mc_id=studentamb_165290" target="_blank" description="Demonstrate foundational knowledge of Microsoft 365 Administration."/>
 
-  <LinkCard title="MS-102 Study Guide" href="https://learn.microsoft.com/credentials/certifications/resources/study-guides/ms-102t00?WT.mc_id=studentamb_165290" target="_blank" description="Study guides contain topics and information you need to know to successfully prepare for the exam."/>
+  <LinkCard title="MS-102 Study Guide" href="https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/ms-102" target="_blank" description="Study guides contain topics and information you need to know to successfully prepare for the exam."/>
   <LinkCard title="Exam Labs" href="/labs/microsoft365/ms-102" target="_blank" description="Collection of all lab exercises that Microsoft offers. Includes Labs for Instructor Lead Trainings, and Applied Skills."/>
 
 ---


### PR DESCRIPTION
the href to the MS-102 study guide in the card is broken, thus fixing with working URL