### PR TITLE
Update exam date for AI-200 beta discount offer to May 27th

### DIFF
--- a/src/content/docs/vouchers/ai200beta.mdx
+++ b/src/content/docs/vouchers/ai200beta.mdx
@@ -19,7 +19,7 @@ import { LinkCard } from "@astrojs/starlight/components";
 </LinkButton>
 
 :::note
-The first 300 people who take Exam AI-200 (beta) on or before May 12, 2026, can get 80% off market price using code **AI200Piedmont**.
+The first 300 people who take Exam AI-200 (beta) on or before May 27, 2026, can get 80% off market price using code **AI200Piedmont**.
 :::
 
 Exam AI-200 is a new beta exam for the Microsoft Certified: Azure AI Cloud Developer Associate.
@@ -29,7 +29,7 @@ Exam AI-200 is a new beta exam for the Microsoft Certified: Azure AI Cloud Devel
 <Steps>
 
 1. Register for [Exam AI-200 (beta)](https://learn.microsoft.com/en-us/credentials/certifications/azure-ai-cloud-developer-associate?WT.mc_id=studentamb_165290).
-2. Schedule to take the exam on or before **May 12, 2026**.
+2. Schedule to take the exam on or before **May 27, 2026**.
 3. When prompted for payment, use the code **AI200Piedmont** to receive the 80% discount.
 
 </Steps>


### PR DESCRIPTION
Linked article mentions "The first 300 people who take Exam AI-200 (beta) on or before **May 27, 2026**, can get 80% off." 

So May 27, not May 12.

Blog: [New Microsoft Certified: Azure AI Cloud Developer Associate Certification](https://techcommunity.microsoft.com/blog/skills-hub-blog/new-microsoft-certified-azure-ai-cloud-developer-associate-certification/4494116)

[MSFTHUB Exam AI-200 (beta)](https://msfthub.com/vouchers/ai200beta/)