### PR TITLE
fix: correct typo in DP-800 Study Guide link URL

### DIFF
--- a/src/content/docs/azure/DP-800.mdx
+++ b/src/content/docs/azure/DP-800.mdx
@@ -14,7 +14,7 @@ If you have any resources that you would like to recommend, please let us know a
 
   <LinkCard title="Exam DP-800: Developing AI-Enabled Database Solutions" href="https://learn.microsoft.com/en-us/credentials/certifications/developing-ai-enabled-database-solutions/?WT.mc_id=studentamb_165290" target="_blank" description="Become adept at building AI‑enabled database solutions across Microsoft SQL platforms, integrating AI features, applying T‑SQL and CI/CD practices, and collaborating with cross‑functional teams to deliver secure, scalable, high‑performance data solutions."/>
 
-  <LinkCard title="DP-800 Study Guide" href="hhttps://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/dp-800?WT.mc_id=studentamb_165290" target="_blank" description="Study guides contain topics and information you need to know to successfully prepare for the exam."/>
+  <LinkCard title="DP-800 Study Guide" href="https://learn.microsoft.com/en-us/credentials/certifications/resources/study-guides/dp-800?WT.mc_id=studentamb_165290" target="_blank" description="Study guides contain topics and information you need to know to successfully prepare for the exam."/>
 
 ---
 <Tabs>


### PR DESCRIPTION
While trying to access DP-800 study material, I noticed a typo within the link URL for the study guide