### PR TITLE
Add CramHQ resources to Azure exam pages

### DIFF
--- a/src/content/docs/azure/AZ-104.mdx
+++ b/src/content/docs/azure/AZ-104.mdx
@@ -39,6 +39,7 @@ import { Aside } from '@astrojs/starlight/components';
   <TabItem label="Tests">
     <LinkCard title="Microsoft Learn Practice Assessment" href="https://learn.microsoft.com/credentials/certifications/azure-administrator/practice/assessment?assessment-type=practice&assessmentId=21&practice-assessment-type=certification&WT.mc_id=studentamb_165290" target="_blank" description="Mini test that shows examples of how exam questions are structured. It is not equivalent to the real exams in format/difficulty. It is easier than real exams."/>
     <CardGrid>
+    <LinkCard title="CramHQ AZ-104 Free Diagnostic Assessment" href="https://cramhq.com/course/az-104-microsoft-azure-administrator" target="_blank" description="Take a free AZ-104 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     <LinkCard title="MeasureUp Assessment" href="https://www.measureup.com/assessment-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="MeasureUp Practice Tests" href="https://www.measureup.com/microsoft-practice-test-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="Whizlab Practice Tests" href="https://www.whizlabs.com/microsoft-azure-certification-az-104/" target="_blank"/>
@@ -56,6 +57,7 @@ import { Aside } from '@astrojs/starlight/components';
     <LinkCard title="MeasureUp Certkit" href="https://www.measureup.com/certkit-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="Cloudguides Follow Labs AZ-104" href="https://www.cloudguides.com/series/AZ-104%3A%20Azure%20Administrator%20Series" target="_blank"/>
     <LinkCard title="John Christopher's Course on Udemy" href="https://www.udemy.com/course/az-104-microsoft-azure-administrator-course-with-simulations/" target="_blank"/>
+    <LinkCard title="CramHQ AZ-104 Pass Plan and Practice Course" href="https://cramhq.com/course/az-104-microsoft-azure-administrator" target="_blank" description="Use targeted remediation, practice quizzes, explanations, and a timed exam simulation to prepare for AZ-104."/>
     </CardGrid>
   </TabItem>
 

--- a/src/content/docs/azure/AZ-104.mdx
+++ b/src/content/docs/azure/AZ-104.mdx
@@ -39,11 +39,11 @@ import { Aside } from '@astrojs/starlight/components';
   <TabItem label="Tests">
     <LinkCard title="Microsoft Learn Practice Assessment" href="https://learn.microsoft.com/credentials/certifications/azure-administrator/practice/assessment?assessment-type=practice&assessmentId=21&practice-assessment-type=certification&WT.mc_id=studentamb_165290" target="_blank" description="Mini test that shows examples of how exam questions are structured. It is not equivalent to the real exams in format/difficulty. It is easier than real exams."/>
     <CardGrid>
-    <LinkCard title="CramHQ AZ-104 Free Diagnostic Assessment" href="https://cramhq.com/course/az-104-microsoft-azure-administrator" target="_blank" description="Take a free AZ-104 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     <LinkCard title="MeasureUp Assessment" href="https://www.measureup.com/assessment-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="MeasureUp Practice Tests" href="https://www.measureup.com/microsoft-practice-test-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="Whizlab Practice Tests" href="https://www.whizlabs.com/microsoft-azure-certification-az-104/" target="_blank"/>
     <LinkCard title="Scott Duffy Practice Tests" href="https://www.udemy.com/course/az104-azure-practice/" target="_blank"/>
+    <LinkCard title="CramHQ AZ-104 Practice Assessment" href="https://cramhq.com/course/az-104-microsoft-azure-administrator" target="_blank" description="Take a free AZ-104 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     </CardGrid>
   </TabItem>
 
@@ -57,7 +57,6 @@ import { Aside } from '@astrojs/starlight/components';
     <LinkCard title="MeasureUp Certkit" href="https://www.measureup.com/certkit-az-104-microsoft-azure-administrator.html#u44" target="_blank"/>
     <LinkCard title="Cloudguides Follow Labs AZ-104" href="https://www.cloudguides.com/series/AZ-104%3A%20Azure%20Administrator%20Series" target="_blank"/>
     <LinkCard title="John Christopher's Course on Udemy" href="https://www.udemy.com/course/az-104-microsoft-azure-administrator-course-with-simulations/" target="_blank"/>
-    <LinkCard title="CramHQ AZ-104 Pass Plan and Practice Course" href="https://cramhq.com/course/az-104-microsoft-azure-administrator" target="_blank" description="Use targeted remediation, practice quizzes, explanations, and a timed exam simulation to prepare for AZ-104."/>
     </CardGrid>
   </TabItem>
 

--- a/src/content/docs/azure/AZ-305.mdx
+++ b/src/content/docs/azure/AZ-305.mdx
@@ -34,9 +34,9 @@ import { Aside } from '@astrojs/starlight/components';
   <TabItem label="Tests">
     <LinkCard title="Microsoft Learn Practice Assessment" href="https://learn.microsoft.com/certifications/exams/az-305/practice/assessment?assessment-type=practice&assessmentId=15&WT.mc_id=studentamb_165290" target="_blank" description="Mini test that shows examples of how exam questions are structured. It is not equivalent to the real exams in format/difficulty. It is easier than real exams."/>
     <CardGrid>
-    <LinkCard title="CramHQ AZ-305 Free Diagnostic Assessment" href="https://cramhq.com/course/designing-microsoft-azure-infrastructure-solutions" target="_blank" description="Take a free AZ-305 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     <LinkCard title="MeasureUp Assessment" href="https://www.measureup.com/assessment-az-305-designing-microsoft-azure-infrastructure-solutions.html#u44" target="_blank"/>
     <LinkCard title="MeasureUp Practice Tests" href="https://www.measureup.com/microsoft-practice-test-az-305-designing-microsoft-azure-infrastructure-solutions.html#u44" target="_blank"/>
+    <LinkCard title="CramHQ AZ-305 Practice Assessment" href="https://cramhq.com/course/designing-microsoft-azure-infrastructure-solutions" target="_blank" description="Take a free AZ-305 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     </CardGrid>
   </TabItem>
 
@@ -47,7 +47,6 @@ import { Aside } from '@astrojs/starlight/components';
     <LinkCard title="edX AZ-305 Solution Architect" href="https://www.edx.org/certificates/professional-certificate/microsoft-az-305-solution-architect" target="_blank"/>
     <LinkCard title="Coursera Packt's Designing Microsoft Azure Infrastructure Solutions (AZ-305) Specialization" href="https://www.coursera.org/specializations/packt-designing-microsoft-azure-infrastructure-solutions-az-305" target="_blank"/>
     <LinkCard title="John Christopher's Course on Udemy" href="https://www.udemy.com/course/az-305-designing-microsoft-azure-infrastructure-with-sims/" target="_blank"/>
-    <LinkCard title="CramHQ AZ-305 Pass Plan and Practice Course" href="https://cramhq.com/course/designing-microsoft-azure-infrastructure-solutions" target="_blank" description="Use targeted remediation, practice quizzes, explanations, and a timed exam simulation to prepare for AZ-305."/>
     </CardGrid>
   </TabItem>
 

--- a/src/content/docs/azure/AZ-305.mdx
+++ b/src/content/docs/azure/AZ-305.mdx
@@ -34,6 +34,7 @@ import { Aside } from '@astrojs/starlight/components';
   <TabItem label="Tests">
     <LinkCard title="Microsoft Learn Practice Assessment" href="https://learn.microsoft.com/certifications/exams/az-305/practice/assessment?assessment-type=practice&assessmentId=15&WT.mc_id=studentamb_165290" target="_blank" description="Mini test that shows examples of how exam questions are structured. It is not equivalent to the real exams in format/difficulty. It is easier than real exams."/>
     <CardGrid>
+    <LinkCard title="CramHQ AZ-305 Free Diagnostic Assessment" href="https://cramhq.com/course/designing-microsoft-azure-infrastructure-solutions" target="_blank" description="Take a free AZ-305 diagnostic assessment to identify weak areas and get a targeted study plan."/>
     <LinkCard title="MeasureUp Assessment" href="https://www.measureup.com/assessment-az-305-designing-microsoft-azure-infrastructure-solutions.html#u44" target="_blank"/>
     <LinkCard title="MeasureUp Practice Tests" href="https://www.measureup.com/microsoft-practice-test-az-305-designing-microsoft-azure-infrastructure-solutions.html#u44" target="_blank"/>
     </CardGrid>
@@ -46,6 +47,7 @@ import { Aside } from '@astrojs/starlight/components';
     <LinkCard title="edX AZ-305 Solution Architect" href="https://www.edx.org/certificates/professional-certificate/microsoft-az-305-solution-architect" target="_blank"/>
     <LinkCard title="Coursera Packt's Designing Microsoft Azure Infrastructure Solutions (AZ-305) Specialization" href="https://www.coursera.org/specializations/packt-designing-microsoft-azure-infrastructure-solutions-az-305" target="_blank"/>
     <LinkCard title="John Christopher's Course on Udemy" href="https://www.udemy.com/course/az-305-designing-microsoft-azure-infrastructure-with-sims/" target="_blank"/>
+    <LinkCard title="CramHQ AZ-305 Pass Plan and Practice Course" href="https://cramhq.com/course/designing-microsoft-azure-infrastructure-solutions" target="_blank" description="Use targeted remediation, practice quizzes, explanations, and a timed exam simulation to prepare for AZ-305."/>
     </CardGrid>
   </TabItem>
 


### PR DESCRIPTION
## Summary
  Adds CramHQ as a third-party study/practice resource for AZ-305 and AZ-104.

  ## Scope
  - Adds a free diagnostic CramHQ LinkCard to each exam page's Tests tab.
  - Adds a CramHQ Pass Plan/practice course LinkCard to each exam page's Paid tab.
  - Keeps copy neutral and resource-focused.
  - No layout, dependency, or configuration changes.

  ## Validation
  - pnpm build