### PR TITLE
Mark AI-500 (beta) 80% discount as fully claimed

### DIFF
--- a/src/content/docs/vouchers/ai500beta.mdx
+++ b/src/content/docs/vouchers/ai500beta.mdx
@@ -1,6 +1,6 @@
 ---
-title: Exam AI-500 (beta)
-description: Get 80% off the new Exam AI-500 (beta) for Multi-Agent AI Solutions Expert.
+title: Exam AI-500 (beta) (Expired)
+description: The 80% off discount for Exam AI-500 (beta) for Multi-Agent AI Solutions Expert has been fully claimed.
 voucherCategory: "Special"
 ---
 
@@ -17,13 +17,17 @@ import { Steps } from "@astrojs/starlight/components";
   Read Official Announcement
 </LinkButton>
 
+:::danger
+All 300 available vouchers have been used. The **AI500Wabash** discount code is no longer usable — attempting to redeem it now returns "This discount is no longer available because it has a use limit, and the use limit has been met."
+:::
+
 :::note
-The first 300 people who take Exam AI-500 (beta) on or before August 5, 2026, can get 80% off market price using code **AI500Wabash**.
+The first 300 people who take Exam AI-500 (beta) on or before August 5, 2026, could get 80% off market price using code **AI500Wabash**.
 :::
 
 Exam AI-500 is the new beta exam for Microsoft Certified: Multi-Agent AI Solutions Expert. It validates your ability to design, build, and operate scalable, production-ready multi-agent AI solutions and workflows.
 
-## How to claim the 80% discount
+## How the 80% discount was claimed
 
 <Steps>
 
@@ -38,7 +42,7 @@ The default **Schedule exam** link on the AI-500 certification page is currently
 :::
 
 :::tip
-This is not a private access code. The seats are offered on a first-come, first-served basis to the first 300 people. This discount is not available in Turkey, Pakistan, India, or China.
+This was not a private access code. The seats were offered on a first-come, first-served basis to the first 300 people, and all 300 have now been claimed. The discount was also not available in Turkey, Pakistan, India, or China.
 :::
 
 Want to learn more about how beta exams work, their incentives, and what to expect? Read our dedicated beta exams page.


### PR DESCRIPTION
Closes #50

### What

The **AI500Wabash** 80% discount for Exam AI-500 (beta) no longer validates — all 300 first-come, first-served seats have been used. Redeeming it now returns:

> This discount is no longer available because it has a use limit, and the use limit has been met.

The page still presented the offer as available, so this marks it as done.

### Changes to `src/content/docs/vouchers/ai500beta.mdx`

- **`:::danger` banner** at the top quoting the exact validation error, so someone who arrives with the code immediately understands why it failed. Follows the existing convention for dead offers (`levelup.mdx`, `partnerweek.mdx`).
- **Title marked `(Expired)`** — deliberately the exact marker `scripts/voucher-expiry-check.sh` appends. The date-based automation would not have caught this (the page's latest date, August 5 2026, is still in the future), and once that date passes its `grep -qi "expired"` guard will now skip the page rather than opening a redundant automated PR.
- **`description` updated** — it's surfaced on the `/vouchers/` index card by `VoucherList.astro`, so it shouldn't keep advertising "Get 80% off".
- **Note, tip, and steps heading reworded to past tense**, keeping the page as a record of what the offer was without implying it's still claimable.

The page keeps `voucherCategory: "Special"` so it stays listed and discoverable — people who heard about the code should be able to find the explanation rather than hit a 404.

### Verification

- `pnpm build` (`astro check && astro build`) passes — 0 errors, 147 pages built.
- No content changes outside this one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
